### PR TITLE
default msbuild path for mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: csharp
-os: osx
+os:
+  - linux
+  - osx
 solution: solution-name.sln
 mono: beta
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,13 @@ language: csharp
 os: osx
 solution: solution-name.sln
 mono: beta
-dotnet: 1.0.3
 
 before_install:
-  - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet2.pkg https://download.microsoft.com/download/7/C/3/7C310A63-13AC-49A4-9666-4CB26388F852/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.pkg
-  - sudo installer -package /tmp/dotnet2.pkg -target / -verboseR
-
+  - wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -O /tmp/nuget.exe
+  - mono /tmp/nuget.exe install xunit.runner.console -Version 2.2.0 -Output /tmp/packages/
 install:
   - msbuild /t:restore
 
 script:
   - msbuild
-  - cd ProjectSimplifier.Tests
-  - dotnet test
+  - mono /tmp/packages/xunit.runner.console.2.2.0/tools/xunit.console.exe ./ProjectSimplifier.Tests/bin/Debug/net461/ProjectSimplifier.Tests.dll 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dotnet: 1.03
 
 -before_install:
   - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet2.pkg https://download.microsoft.com/download/7/C/3/7C310A63-13AC-49A4-9666-4CB26388F852/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.pkg
-  - sudo installer -package "/tmp/dotnet2.pkg" -target "/" -verboseR
+  - sudo installer -package /tmp/dotnet2.pkg -target / -verboseR
 
 script:
   - msbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: csharp
 os: osx
 solution: solution-name.sln
 mono: beta
-dotnet: 2.0.0-preview2-006497
+dotnet: 1.03
+
+-before_install:
+  - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet2.pkg https://download.microsoft.com/download/7/C/3/7C310A63-13AC-49A4-9666-4CB26388F852/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.pkg
+  - sudo installer -package "/tmp/dotnet2.pkg" -target "/" -verboseR
 
 script:
   - msbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+os: osx
+solution: solution-name.sln
+mono: beta
+dotnet: 2.0.0-preview2-006497
+
+script:
+  - msbuild
+  - cd ProjectSimplifier.Tests
+  - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ solution: solution-name.sln
 mono: beta
 dotnet: 1.0.3
 
--before_install:
+before_install:
   - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet2.pkg https://download.microsoft.com/download/7/C/3/7C310A63-13AC-49A4-9666-4CB26388F852/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.pkg
   - sudo installer -package /tmp/dotnet2.pkg -target / -verboseR
+
+install:
+  - msbuild /t:restore
 
 script:
   - msbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: csharp
-os:
-  - linux
-  - osx
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+
 solution: solution-name.sln
 mono: beta
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 os: osx
 solution: solution-name.sln
 mono: beta
-dotnet: 1.03
+dotnet: 1.0.3
 
 -before_install:
   - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet2.pkg https://download.microsoft.com/download/7/C/3/7C310A63-13AC-49A4-9666-4CB26388F852/dotnet-runtime-2.0.0-preview2-25407-01-osx-x64.pkg

--- a/ProjectSimplifier/Program.cs
+++ b/ProjectSimplifier/Program.cs
@@ -99,9 +99,9 @@ namespace ProjectSimplifier
             }else{
                 //Second chance for mono 
                 var systemLibLocation = typeof(System.Object).Assembly.Location;
-                var monoMSBuildPath = Path.Combine(Path.GetDirectoryName(systemLibLocation),"..","MSBuild", "15.0", "Bin");
+                var monoMSBuildPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(systemLibLocation),"..","msbuild", "15.0", "bin"));
                 if(Directory.Exists(monoMSBuildPath)){
-                    return Path.GetFullPath(monoMSBuildPath);
+		    return Path.GetFullPath(monoMSBuildPath);
                 }
                 
             }

--- a/ProjectSimplifier/Program.cs
+++ b/ProjectSimplifier/Program.cs
@@ -96,6 +96,14 @@ namespace ProjectSimplifier
                 var path = Path.Combine(vsinstalldir, "MSBuild", "15.0", "Bin");
                 Console.WriteLine($"Found VS from VSINSTALLDIR (Dev Console): {path}");
                 return path;
+            }else{
+                //Second chance for mono 
+                var systemLibLocation = typeof(System.Object).Assembly.Location;
+                var monoMSBuildPath = Path.Combine(Path.GetDirectoryName(systemLibLocation),"..","MSBuild", "15.0", "Bin");
+                if(Directory.Exists(monoMSBuildPath)){
+                    return Path.GetFullPath(monoMSBuildPath);
+                }
+                
             }
 
             return null;


### PR DESCRIPTION
So you don't have to use the `-m` flag all the time on Mac or Linux

Also added ci config for [travisci](https://travis-ci.org) that builds and runs unit tests on Mac and Linux.